### PR TITLE
feat(logging): Implement file emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,12 @@ yarn:
 ```bash
 yarn add @intelika/logger
 ```
-pnpm:
-```bash
-pnpm add @intelika/logger
-```
-bun:
-```bash
-bun add @intelika/logger
-```
+
+## Emitters
+- [File](./lib/log/emitters/file.emitter.ts)
+- [Telegram](./lib/log/emitters/telegram.emitter.ts)
+- [Discord Webhook](./lib/log/emitters/discord.emitter.ts)
+- [Console](./lib/log/emitters/console.emitter.ts)
 
 ## Usage
 the package can be used in any JavaScript or TypeScript project. Here are some examples of how to use it in different environments.
@@ -123,6 +121,22 @@ logger.error('Something went wrong!').into(Emitter.TELEGRAM);
 > })
 >```
 > you can use the discord emitter by providing the webhook url.
+
+> [!TIP]
+> ```ts
+> const logService = new LogService('TestContext', {
+>  file: {
+>    path: './logs',
+>    includeDateInFilename: true,
+>    fileFormat: 'log',
+>    messageFormat: 'DATE - LEVEL | CONTEXT | MESSAGE'
+>  }
+>})
+>```
+> you can use the file emitter by providing the path of the file, the file format, and the message format.
+
+## Examples
+you can find more examples in the [examples](./examples) directory.
 
 ## API
 

--- a/examples/fileEmitter/example-1.ts
+++ b/examples/fileEmitter/example-1.ts
@@ -1,0 +1,13 @@
+import { Emitter, LogService } from '../..'
+
+const logService = new LogService('TestContext', {
+  file: {
+    path: './log.txt',
+    messageFormat: 'DATE - LEVEL | CONTEXT | MESSAGE'
+  }
+})
+
+logService.log('This is an info message').into(Emitter.FILE)
+logService.warn('This is a warning message').into(Emitter.FILE)
+logService.error('This is an error message').into(Emitter.FILE)
+logService.error(new Error('This is an error message')).into(Emitter.FILE)

--- a/examples/fileEmitter/example-2.ts
+++ b/examples/fileEmitter/example-2.ts
@@ -1,0 +1,14 @@
+import { Emitter, LogService } from '../../dist'
+
+const logService = new LogService('TestContext', {
+  file: {
+    path: './logs',
+    includeDateInFilename: true,
+    fileFormat: 'log',
+    messageFormat: 'DATE - LEVEL | CONTEXT | MESSAGE'
+  }
+})
+
+logService.log('This is an info message').into(Emitter.FILE)
+logService.warn('This is a warning message').into(Emitter.FILE)
+logService.error(new Error('This is an error message')).into(Emitter.FILE)

--- a/lib/log/emitters/file.emitter.ts
+++ b/lib/log/emitters/file.emitter.ts
@@ -1,0 +1,92 @@
+import path from 'path'
+import { consoleColors, PACKAGE_NAME } from '../../config'
+import { Options } from '../interfaces/option.interface'
+import { writeFile } from 'fs/promises'
+import fs from 'fs'
+
+type LogLevel = 'WARN' | 'INFO' | 'ERROR' | 'info'
+
+const NEWLINE = `\n`
+function serializeMessage(...messages: any[]) {
+  const payload = []
+  const firstMessage = messages.shift()
+  payload.push(`${stringifyMessage(firstMessage)}`)
+  for (const msg of messages) {
+    if (msg.stack) payload.push(`${msg.stack}`)
+    else if (typeof msg === 'object') payload.push(`${JSON.stringify(msg, null, 2)}`)
+    else if (typeof msg === 'number') payload.push(`${msg}`)
+    else payload.push(msg.toString())
+  }
+  return payload.join(NEWLINE)
+}
+
+function stringifyMessage(msg: any) {
+  if (msg.stack) return msg.stack
+  if (typeof msg === 'object') return JSON.stringify(msg, null, 2)
+  return msg.toString()
+}
+
+const fileEmitter = async (options: Options, level: LogLevel, context: string, ...msg: any[]) => {
+  if (!options) {
+    return console.warn(`[${PACKAGE_NAME}] ${consoleColors.red}No options provided!${consoleColors.reset}`)
+  }
+
+  if (!options?.file) {
+    return console.warn(
+      `[${PACKAGE_NAME}] ${consoleColors.red}No file options provided!${consoleColors.reset}`
+    )
+  }
+
+  if (!options.file.path) {
+    return console.warn(`[${PACKAGE_NAME}] ${consoleColors.red}No file path provided!${consoleColors.reset}`)
+  }
+
+  const format = options?.file?.messageFormat || 'DATE - LEVEL | CONTEXT | MESSAGE'
+  const message = format
+    .replace('DATE', new Date().toISOString())
+    .replace('LEVEL', level)
+    .replace('CONTEXT', context)
+    .replace('MESSAGE', serializeMessage(...msg))
+
+  const flag = options.file.flags || 'a'
+
+  const inputPath = path.resolve(options.file.path) // can be file or directory
+  const fileFormat = options.file.fileFormat || 'txt'
+  if (path.extname(inputPath)) {
+    const outputPath = inputPath + `.${fileFormat}`
+    await write(outputPath, message, flag)
+  } else {
+    const filename = options.file.includeDateInFilename
+      ? `${new Date().toISOString().split('T')[0]}-${path.basename(inputPath)}.${fileFormat}`
+      : path.basename(inputPath)
+
+    try {
+      const isExists = await fs.promises.stat(inputPath).catch(() => false)
+      if (!isExists) {
+        await fs.promises.mkdir(inputPath, { recursive: true })
+      }
+
+      const outputPath = path.resolve(inputPath, filename)
+
+      write(outputPath, message, flag)
+    } catch (error) {
+      return console.warn(
+        `[${PACKAGE_NAME}] ${consoleColors.red}Error writing to file!${consoleColors.reset}`,
+        error
+      )
+    }
+  }
+}
+
+async function write(outputPath: string, message: string, flag: string) {
+  try {
+    await writeFile(outputPath, message + NEWLINE, { flag })
+  } catch (error) {
+    return console.warn(
+      `[${PACKAGE_NAME}] ${consoleColors.red}Error writing to file!${consoleColors.reset}`,
+      error
+    )
+  }
+}
+
+export default fileEmitter

--- a/lib/log/emitters/file.emitter.ts
+++ b/lib/log/emitters/file.emitter.ts
@@ -1,47 +1,46 @@
+import fs from 'fs'
 import path from 'path'
+import { writeFile } from 'fs/promises'
 import { consoleColors, PACKAGE_NAME } from '../../config'
 import { Options } from '../interfaces/option.interface'
-import { writeFile } from 'fs/promises'
-import fs from 'fs'
 
-type LogLevel = 'WARN' | 'INFO' | 'ERROR' | 'info'
+type LogLevel = 'WARN' | 'INFO' | 'ERROR'
 
 const NEWLINE = `\n`
-function serializeMessage(...messages: any[]) {
-  const payload = []
+
+function serializeMessage(...messages: any[]): string {
+  const payload: string[] = []
   const firstMessage = messages.shift()
-  payload.push(`${stringifyMessage(firstMessage)}`)
+  payload.push(stringifyMessage(firstMessage))
   for (const msg of messages) {
-    if (msg.stack) payload.push(`${msg.stack}`)
-    else if (typeof msg === 'object') payload.push(`${JSON.stringify(msg, null, 2)}`)
-    else if (typeof msg === 'number') payload.push(`${msg}`)
+    if (msg.stack) payload.push(msg.stack)
+    else if (typeof msg === 'object') payload.push(JSON.stringify(msg, null, 2))
+    else if (typeof msg === 'number') payload.push(msg.toString())
     else payload.push(msg.toString())
   }
   return payload.join(NEWLINE)
 }
 
-function stringifyMessage(msg: any) {
+function stringifyMessage(msg: any): string {
   if (msg.stack) return msg.stack
   if (typeof msg === 'object') return JSON.stringify(msg, null, 2)
   return msg.toString()
 }
 
-const fileEmitter = async (options: Options, level: LogLevel, context: string, ...msg: any[]) => {
-  if (!options) {
-    return console.warn(`[${PACKAGE_NAME}] ${consoleColors.red}No options provided!${consoleColors.reset}`)
-  }
-
-  if (!options?.file) {
-    return console.warn(
-      `[${PACKAGE_NAME}] ${consoleColors.red}No file options provided!${consoleColors.reset}`
+async function fileEmitter(options: Options, level: LogLevel, context: string, ...msg: any[]): Promise<void> {
+  if (!options || !options.file) {
+    console.warn(
+      `[${PACKAGE_NAME}] ${consoleColors.red}No options provided or file options provided!${consoleColors.reset}`
     )
+    return
   }
 
   if (!options.file.path) {
-    return console.warn(`[${PACKAGE_NAME}] ${consoleColors.red}No file path provided!${consoleColors.reset}`)
+    console.warn(`[${PACKAGE_NAME}] ${consoleColors.red}No file path provided!${consoleColors.reset}`)
+    return
   }
 
-  const format = options?.file?.messageFormat || 'DATE - LEVEL | CONTEXT | MESSAGE'
+  const format = options.file.messageFormat || 'DATE - LEVEL | CONTEXT | MESSAGE'
   const message = format
     .replace('DATE', new Date().toISOString())
     .replace('LEVEL', level)
@@ -50,42 +49,42 @@ const fileEmitter = async (options: Options, level: LogLevel, context: string, .
 
   const flag = options.file.flags || 'a'
 
-  const inputPath = path.resolve(options.file.path) // can be file or directory
+  const inputPath = path.resolve(options.file.path)
   const fileFormat = options.file.fileFormat || 'txt'
-  if (path.extname(inputPath)) {
-    const outputPath = inputPath + `.${fileFormat}`
-    await write(outputPath, message, flag)
-  } else {
-    const filename = options.file.includeDateInFilename
-      ? `${new Date().toISOString().split('T')[0]}-${path.basename(inputPath)}.${fileFormat}`
-      : path.basename(inputPath)
 
-    try {
-      const isExists = await fs.promises.stat(inputPath).catch(() => false)
-      if (!isExists) {
-        await fs.promises.mkdir(inputPath, { recursive: true })
-      }
+  try {
+    const isDirectory = !path.extname(inputPath)
+    if (isDirectory) {
+      const filename = options.file.includeDateInFilename
+        ? `${new Date().toISOString().split('T')[0]}-${path.basename(inputPath)}.${fileFormat}`
+        : path.basename(inputPath)
 
       const outputPath = path.resolve(inputPath, filename)
 
-      write(outputPath, message, flag)
-    } catch (error) {
-      return console.warn(
-        `[${PACKAGE_NAME}] ${consoleColors.red}Error writing to file!${consoleColors.reset}`,
-        error
-      )
+      const outputDir = path.dirname(outputPath)
+      await fs.promises.mkdir(outputDir, { recursive: true })
+
+      await writeFile(outputPath, message + NEWLINE, { flag })
+    } else {
+      const outputPath = inputPath
+
+      const isExists = await fs.promises.stat(path.dirname(inputPath)).catch(() => false)
+      if (!isExists) {
+        await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
+      }
+
+      await writeToFile(outputPath, message, flag)
     }
+  } catch (error) {
+    console.warn(`[${PACKAGE_NAME}] ${consoleColors.red}Error writing to file!${consoleColors.reset}`, error)
   }
 }
 
-async function write(outputPath: string, message: string, flag: string) {
+async function writeToFile(outputPath: string, message: string, flag: string): Promise<void> {
   try {
     await writeFile(outputPath, message + NEWLINE, { flag })
   } catch (error) {
-    return console.warn(
-      `[${PACKAGE_NAME}] ${consoleColors.red}Error writing to file!${consoleColors.reset}`,
-      error
-    )
+    console.warn(`[${PACKAGE_NAME}] ${consoleColors.red}Error writing to file!${consoleColors.reset}`, error)
   }
 }
 

--- a/lib/log/interfaces/asyncOptions.interface.ts
+++ b/lib/log/interfaces/asyncOptions.interface.ts
@@ -1,4 +1,4 @@
-import { Options } from './option.interface'
+import { NestOptions, Options } from './option.interface'
 
 /**
  * @interface AsyncOptions
@@ -18,7 +18,7 @@ import { Options } from './option.interface'
  * }
  */
 
-export interface AsyncOptions extends Options {
+export interface AsyncOptions extends NestOptions {
   useFactory?: (...args: any[]) => Promise<Options> | Options
 
   inject?: any[]

--- a/lib/log/interfaces/option.interface.ts
+++ b/lib/log/interfaces/option.interface.ts
@@ -40,4 +40,28 @@ export interface Options {
     token: string
     chatId: string
   }
+
+  /**
+   * Options for the file emitter.
+   * @property path - The path for the file or directory.
+   * @property includeDateInFilename - Whether to include the date in the filename. [when path is a directory]
+   * @property fileFormat - The format of the file. [txt | log]
+   * @property flags - The flags for writing to the file. [a | w | r | a+ | w+ | r+]
+   * @property messageFormat - The format of the message. [DATE | LEVEL | CONTEXT | MESSAGE]
+   * @default undefined
+   * @example { path: './logs', includeDateInFilename: true, fileFormat: 'log', messageFormat: 'DATE - LEVEL | CONTEXT | MESSAGE' }
+   */
+  file?: {
+    path: string // can be a file path or a directory path
+    includeDateInFilename?: boolean
+    fileFormat?: 'txt' | 'log'
+    flags?: string // 'a' | 'w' | 'r' | 'a+' | 'w+' | 'r+'
+    messageFormat?:
+      | 'DATE | LEVEL | CONTEXT | MESSAGE'
+      | 'DATE - LEVEL | CONTEXT | MESSAGE'
+      | 'DATE | CONTEXT | MESSAGE'
+      | 'DATE - CONTEXT | MESSAGE'
+      | 'DATE | MESSAGE'
+      | 'DATE - MESSAGE'
+  }
 }

--- a/lib/log/interfaces/option.interface.ts
+++ b/lib/log/interfaces/option.interface.ts
@@ -18,12 +18,6 @@
 
 export interface Options {
   /**
-   * Whether the module is global.
-   * @default false
-   */
-  isGlobal?: boolean
-
-  /**
    * The Discord webhook URL.
    * @default undefined
    * @example 'https://discord.com/api/webhooks/...'
@@ -64,4 +58,18 @@ export interface Options {
       | 'DATE | MESSAGE'
       | 'DATE - MESSAGE'
   }
+}
+
+/**
+ * @interface NestOptions
+ * Represents a set of options for configuring the logger service.
+ * @property isGlobal - Whether the module is global.
+ * @default false
+ */
+export interface NestOptions extends Options {
+  /**
+   * Whether the module is global.
+   * @default false
+   */
+  isGlobal?: boolean
 }

--- a/lib/log/log.module.ts
+++ b/lib/log/log.module.ts
@@ -1,7 +1,7 @@
 import { Module, DynamicModule, Provider } from '@nestjs/common'
 import { LogService } from './log.service'
 import 'reflect-metadata'
-import { Options } from './interfaces/option.interface'
+import { NestOptions } from './interfaces/option.interface'
 import { AsyncOptions } from './interfaces/asyncOptions.interface'
 
 @Module({
@@ -19,7 +19,7 @@ export class LogModule {
    * @param opts - The options for configuring the LogModule.
    * @returns A dynamic module configuration object.
    */
-  static forRoot(opts: Options): DynamicModule {
+  static forRoot(opts: NestOptions): DynamicModule {
     const logServiceProvider: Provider = {
       provide: LogService,
       useFactory: () => {

--- a/lib/log/log.service.ts
+++ b/lib/log/log.service.ts
@@ -11,7 +11,8 @@ import { Message } from './message'
 export enum Emitter {
   'DISCORD' = 'DISCORD',
   'TELEGRAM' = 'TELEGRAM',
-  'CONSOLE' = 'CONSOLE'
+  'CONSOLE' = 'CONSOLE',
+  'FILE' = 'FILE'
 }
 
 /**

--- a/lib/log/message.ts
+++ b/lib/log/message.ts
@@ -3,6 +3,7 @@ import consoleEmitter from './emitters/console.emitter'
 import discordEmitter from './emitters/discord.emitter'
 import telegramEmitter from './emitters/telegram.emitter'
 import { Options } from './interfaces/option.interface'
+import fileEmitter from './emitters/file.emitter'
 type LogLevel = 'WARN' | 'INFO' | 'ERROR'
 
 export class Message {
@@ -30,7 +31,8 @@ export class Message {
     const emitters: Record<Emitter, any> = {
       CONSOLE: consoleEmitter,
       DISCORD: discordEmitter,
-      TELEGRAM: telegramEmitter
+      TELEGRAM: telegramEmitter,
+      FILE: fileEmitter
     }
     const emitterFunc = emitters[emitter]
     if (!emitterFunc) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "removeComments": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "es2017",
     "sourceMap": true,


### PR DESCRIPTION
This pull request introduces a new file emitter for the logging service, which allows writing logs to files or directories with customizable options.

### Features

- Add a file emitter for writing logs to files or directories.
- Support for configurable options such as file path, file format, date inclusion in filename, and message format.
- Examples demonstrating the usage of the file emitter.
